### PR TITLE
Fix centering on UI when scaled

### DIFF
--- a/Stardew-Valley-Mods/HorseOverhaul/HorseMenu.cs
+++ b/Stardew-Valley-Mods/HorseOverhaul/HorseMenu.cs
@@ -26,7 +26,7 @@
         private readonly HorseOverhaul mod;
 
         public HorseMenu(HorseOverhaul mod, HorseWrapper horse)
-          : base((Game1.viewport.Width / 2) - (HorseMenu.width / 2), (Game1.viewport.Height / 2) - (HorseMenu.height / 2), HorseMenu.width, HorseMenu.height, false)
+          : base((Game1.uiViewport.Width / 2) - (HorseMenu.width / 2), (Game1.uiViewport.Height / 2) - (HorseMenu.height / 2), HorseMenu.width, HorseMenu.height, false)
         {
             this.mod = mod;
             this.horse = horse;
@@ -37,7 +37,7 @@
             HorseMenu.height = Game1.tileSize * 8;
 
             this.textBox = new TextBox(null, null, Game1.dialogueFont, Game1.textColor);
-            this.textBox.X = (Game1.viewport.Width / 2) - (Game1.tileSize * 2) - 12;
+            this.textBox.X = (Game1.uiViewport.Width / 2) - (Game1.tileSize * 2) - 12;
             this.textBox.Y = this.yPositionOnScreen - 4 + (Game1.tileSize * 2);
             this.textBox.Width = Game1.tileSize * 4;
             this.textBox.Height = Game1.tileSize * 3;
@@ -101,23 +101,23 @@
         public override void update(GameTime time)
         {
             base.update(time);
-            int num1 = Game1.getOldMouseX() + Game1.viewport.X;
-            int num2 = Game1.getOldMouseY() + Game1.viewport.Y;
+            int num1 = Game1.getOldMouseX() + Game1.uiViewport.X;
+            int num2 = Game1.getOldMouseY() + Game1.uiViewport.Y;
 
-            if (num1 - Game1.viewport.X < Game1.tileSize)
+            if (num1 - Game1.uiViewport.X < Game1.tileSize)
             {
                 Game1.panScreen(-8, 0);
             }
-            else if (num1 - (Game1.viewport.X + Game1.viewport.Width) >= -Game1.tileSize)
+            else if (num1 - (Game1.uiViewport.X + Game1.uiViewport.Width) >= -Game1.tileSize)
             {
                 Game1.panScreen(8, 0);
             }
 
-            if (num2 - Game1.viewport.Y < Game1.tileSize)
+            if (num2 - Game1.uiViewport.Y < Game1.tileSize)
             {
                 Game1.panScreen(0, -8);
             }
-            else if (num2 - (Game1.viewport.Y + Game1.viewport.Height) >= -Game1.tileSize)
+            else if (num2 - (Game1.uiViewport.Y + Game1.uiViewport.Height) >= -Game1.tileSize)
             {
                 Game1.panScreen(0, 8);
             }

--- a/Stardew-Valley-Mods/HorseOverhaul/PetMenu.cs
+++ b/Stardew-Valley-Mods/HorseOverhaul/PetMenu.cs
@@ -27,7 +27,7 @@
         private readonly HorseOverhaul mod;
 
         public PetMenu(HorseOverhaul mod, Pet pet)
-          : base((Game1.viewport.Width / 2) - (PetMenu.width / 2), (Game1.viewport.Height / 2) - (PetMenu.height / 2), PetMenu.width, PetMenu.height, false)
+          : base((Game1.uiViewport.Width / 2) - (PetMenu.width / 2), (Game1.uiViewport.Height / 2) - (PetMenu.height / 2), PetMenu.width, PetMenu.height, false)
         {
             this.mod = mod;
             this.pet = pet;
@@ -38,7 +38,7 @@
             PetMenu.height = Game1.tileSize * 8;
 
             this.textBox = new TextBox(null, null, Game1.dialogueFont, Game1.textColor);
-            this.textBox.X = (Game1.viewport.Width / 2) - (Game1.tileSize * 2) - 12;
+            this.textBox.X = (Game1.uiViewport.Width / 2) - (Game1.tileSize * 2) - 12;
             this.textBox.Y = this.yPositionOnScreen - 4 + (Game1.tileSize * 2);
             this.textBox.Width = Game1.tileSize * 4;
             this.textBox.Height = Game1.tileSize * 3;
@@ -102,23 +102,23 @@
         public override void update(GameTime time)
         {
             base.update(time);
-            int num1 = Game1.getOldMouseX() + Game1.viewport.X;
-            int num2 = Game1.getOldMouseY() + Game1.viewport.Y;
+            int num1 = Game1.getOldMouseX() + Game1.uiViewport.X;
+            int num2 = Game1.getOldMouseY() + Game1.uiViewport.Y;
 
-            if (num1 - Game1.viewport.X < Game1.tileSize)
+            if (num1 - Game1.uiViewport.X < Game1.tileSize)
             {
                 Game1.panScreen(-8, 0);
             }
-            else if (num1 - (Game1.viewport.X + Game1.viewport.Width) >= -Game1.tileSize)
+            else if (num1 - (Game1.uiViewport.X + Game1.uiViewport.Width) >= -Game1.tileSize)
             {
                 Game1.panScreen(8, 0);
             }
 
-            if (num2 - Game1.viewport.Y < Game1.tileSize)
+            if (num2 - Game1.uiViewport.Y < Game1.tileSize)
             {
                 Game1.panScreen(0, -8);
             }
-            else if (num2 - (Game1.viewport.Y + Game1.viewport.Height) >= -Game1.tileSize)
+            else if (num2 - (Game1.uiViewport.Y + Game1.uiViewport.Height) >= -Game1.tileSize)
             {
                 Game1.panScreen(0, 8);
             }


### PR DESCRIPTION
Took a look at the Pet and Horse menus to look for scaling issues. The easiest way I've found to check for issues is to adjust the game settings and set UI Scale to 150% and Zoom level to 75%, check how the menus display, then set the UI Scaling to 75% and Zoom level to 200% and check the menus again.

I found that the menus weren't being centered when the scale was changed, so I added a fix here following the guidelines from this article: https://stardewcommunitywiki.com/Modding:Migrate_to_Stardew_Valley_1.5#UI_scale_changes

Everything else looks pretty good, but I do agree you should probably move the bulk of the code into a base class. Technically, I don't think you need the receiveKeyPress() method because these menus aren't interactive, but it might make sense to keep it in case you want to add functionality later.