### PR TITLE
Suppress the button so that the game does not handle it

### DIFF
--- a/Stardew-Valley-Mods/DropItHotkey/DropItHotkey.cs
+++ b/Stardew-Valley-Mods/DropItHotkey/DropItHotkey.cs
@@ -27,6 +27,7 @@ namespace DropItHotkey
         {
             if (config.DropKey.JustPressed())
             {
+                Helper.Input.SuppressActiveKeybinds(config.DropKey);
                 if (Context.IsPlayerFree)
                 {
                     Item item = Game1.player.CurrentItem;


### PR DESCRIPTION
Useful for overriding a button function when playing with a controller