### PR TITLE
Update to SMA-PI apis, use IRawTextureData.

### DIFF
--- a/Stardew-Valley-Mods/HorseOverhaul/manifest.json
+++ b/Stardew-Valley-Mods/HorseOverhaul/manifest.json
@@ -5,6 +5,6 @@
   "Description": "Thin horse with saddle bags. Give your horse pets, food and water for friendship and increased speed.",
   "UniqueID": "Goldenrevolver.HorseOverhaul",
   "EntryDll": "HorseOverhaul.dll",
-  "MinimumApiVersion": "3.13.2",
+  "MinimumApiVersion": "3.15.1",
   "UpdateKeys": [ "Nexus:7911" ]
 }


### PR DESCRIPTION
Hey Golden, how have you've been doing?

Basically, just ahead of Pathos bumping up deprecation warnings to be player visible, I'm going through and sending out PRs to update to the new [SMAPI content API](https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Content). 

Additionally:
- Uses IRawTextureData (which improves performance as it avoids GetData)
- Uses ArrayPool to reduce allocations.