### PR TITLE
[Animals Die] Update Animals Need Water API interface

### DIFF
--- a/Stardew-Valley-Mods/AnimalsDie/AnimalsDie.cs
+++ b/Stardew-Valley-Mods/AnimalsDie/AnimalsDie.cs
@@ -31,9 +31,7 @@
 
     public interface IAnimalsNeedWaterAPI
     {
-        List<string> GetCoopsWithWateredTrough();
-
-        List<string> GetBarnsWithWateredTrough();
+        List<string> GetBuildingsWithWateredTrough();
 
         List<long> GetAnimalsLeftThirstyYesterday();
 


### PR DESCRIPTION
This updates the interface of Animals Need Water to match the current version. 1.6.0 merged barns and coops into one single array of buildings, so the API interface had to change as well.