### PR TITLE
Update Automate compatibility

### DIFF
--- a/Stardew-Valley-Mods/ForageFantasy/Compatibility/AutomateCompatibility.cs
+++ b/Stardew-Valley-Mods/ForageFantasy/Compatibility/AutomateCompatibility.cs
@@ -29,7 +29,7 @@
                 var mushroomBox = AccessTools.TypeByName("Pathoschild.Stardew.Automate.Framework.MachineWrapper");
 
                 harmony.Patch(
-                   original: AccessTools.Method(tapper, "OnOutputCollected"),
+                   original: AccessTools.Method(tapper, "GetOutput"),
                    prefix: new HarmonyMethod(typeof(AutomateCompatibility), nameof(PatchTapperMachineOutput)));
 
                 harmony.Patch(

--- a/Stardew-Valley-Mods/ForageFantasy/Patches/Patcher.cs
+++ b/Stardew-Valley-Mods/ForageFantasy/Patches/Patcher.cs
@@ -17,7 +17,7 @@
             try
             {
                 harmony.Patch(
-                   original: AccessTools.Method(typeof(Crop), nameof(Crop.getRandomWildCropForSeason)),
+                   original: AccessTools.Method(typeof(Crop), nameof(Crop.getRandomWildCropForSeason), new Type[] { typeof(Season) }),
                    postfix: new HarmonyMethod(typeof(Patcher), nameof(PatchSummerWildSeedResult)));
 
                 ForageCalendar.ApplyPatches(forageFantasy, harmony);

--- a/Stardew-Valley-Mods/ForageFantasy/manifest.json
+++ b/Stardew-Valley-Mods/ForageFantasy/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Forage Fantasy",
   "Author": "Goldenrevolver",
-  "Version": "4.3.1",
+  "Version": "4.3.2-unofficial.1-justastranger",
   "Description": "Tappers, mushroom boxes and berry bushes give products with quality, and much more",
   "UniqueID": "Goldenrevolver.ForageFantasy",
   "EntryDll": "ForageFantasy.dll",

--- a/Stardew-Valley-Mods/ForageFantasy/manifest.json
+++ b/Stardew-Valley-Mods/ForageFantasy/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Forage Fantasy",
   "Author": "Goldenrevolver",
-  "Version": "4.3.2-unofficial.1-justastranger",
+  "Version": "4.3.2-unofficial.2-justastranger",
   "Description": "Tappers, mushroom boxes and berry bushes give products with quality, and much more",
   "UniqueID": "Goldenrevolver.ForageFantasy",
   "EntryDll": "ForageFantasy.dll",


### PR DESCRIPTION
Tree Tapper specific logic was mostly removed in Automate, now it's necessary to patch the base object that replaced it and mirror the IsTapper check that is present there

Also swapped out a couple of deprecated function calls in the same file.